### PR TITLE
add `tbaa.struct` metadata to LLVM dialect

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -984,6 +984,71 @@ def LLVM_TBAATagArrayAttr
 }
 
 //===----------------------------------------------------------------------===//
+// TBAAStructTagAttr
+//===----------------------------------------------------------------------===//
+def LLVM_TBAAStructMemberAttr : LLVM_Attr<"TBAAStructMember", "tbaa_struct_member"> {
+  let parameters = (ins
+    "int64_t":$offset,
+    "int64_t":$size,
+    "TBAATagAttr":$tag
+  );
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "int64_t":$offset,
+                                        "int64_t":$size,
+                                        "TBAATagAttr":$tag), [{
+      return $_get(tag.getContext(), offset, size, tag);
+    }]>
+  ];
+
+  let assemblyFormat = "`<` params `>`";
+}
+
+def LLVM_TBAAStructMemberAttrArray : ArrayRefParameter<"TBAAStructMemberAttr"> {
+  let printer = [{
+    $_printer << '{';
+    llvm::interleaveComma($_self, $_printer, [&](TBAAStructMemberAttr attr) {
+        $_printer.printStrippedAttrOrType(attr);
+    });
+    $_printer << '}';
+  }];
+
+  let parser = [{
+    [&]() -> FailureOr<SmallVector<TBAAStructMemberAttr>> {
+        using Result = SmallVector<TBAAStructMemberAttr>;
+        if ($_parser.parseLBrace())
+            return failure();
+        FailureOr<Result> result = FieldParser<Result>::parse($_parser);
+        if (failed(result))
+            return failure();
+        if ($_parser.parseRBrace())
+            return failure();
+        return result;
+    }()
+  }];
+}
+
+def LLVM_TBAAStructTagAttr : LLVM_Attr<"TBAAStructTag", "tbaa_struct_tag"> {
+  let parameters = (ins LLVM_TBAAStructMemberAttrArray:$members);
+
+  let summary = "LLVM dialect TBAA struct metadata";
+  let description = [{
+    Describes which memory subregions in a memcpy are padded and what the TBAA
+    tags of the struct are.
+
+    Example:
+    ```mlir
+    #tbaa_struct = #llvm.tbaa_struct_tag<members={<offset, size, tag>, <offset, size, tag>, ... }>
+    ```
+
+    See the following link for more details:
+    https://llvm.org/docs/LangRef.html#tbaa-struct-metadata
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+//===----------------------------------------------------------------------===//
 // VScaleRangeAttr
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
@@ -249,6 +249,43 @@ def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
   ];
 }
 
+def TBAAStructOpInterface : OpInterface<"TBAAStructOpInterface"> {
+  let description = [{
+    An interface for memory operations that can carry TBAA struct information.
+    It provides setters and getters for the operation's TBAA struct
+    attribute. The default implementations of the interface methods expect
+    the operation to have an attribute of type TBAAStructTag named tbaa_struct.
+  }];
+
+  let cppNamespace = "::mlir::LLVM";
+
+  let methods = [
+    InterfaceMethod<
+       /*desc=*/        "Returns the tbaa_struct attribute or nullptr",
+       /*returnType=*/  "TBAAStructTagAttr",
+       /*methodName=*/  "getTBAAStructTagOrNull",
+       /*args=*/        (ins),
+       /*methodBody=*/  [{}],
+       /*defaultImpl=*/ [{
+         auto op = cast<ConcreteOp>(this->getOperation());
+         return op.getTbaaStructAttr();
+       }]
+       >,
+     InterfaceMethod<
+       /*desc=*/        "Sets the tbaa_struct attribute",
+       /*returnType=*/  "void",
+       /*methodName=*/  "setTBAAStructTag",
+       /*args=*/        (ins "const TBAAStructTagAttr":$attr),
+       /*methodBody=*/  [{}],
+       /*defaultImpl=*/ [{
+         auto op = cast<ConcreteOp>(this->getOperation());
+         op.setTbaaStructAttr(attr);
+       }]
+       >
+  ];
+}
+
+
 def GetResultPtrElementType : OpInterface<"GetResultPtrElementType"> {
   let description = [{
     An interface for operations that yield an LLVMPointer. Allows the

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -167,7 +167,8 @@ def LLVM_SMinOp : LLVM_BinarySameArgsIntrOpI<"smin">;
 def LLVM_UMaxOp : LLVM_BinarySameArgsIntrOpI<"umax">;
 def LLVM_UMinOp : LLVM_BinarySameArgsIntrOpI<"umin">;
 
-class LLVM_MemcpyIntrOpBase<string name, list<Trait> traits = []> :
+class LLVM_MemcpyIntrOpBase<string name, list<Trait> traits = [],
+                            bit requiresTBAAStruct = 0> :
     LLVM_ZeroResultIntrOp<name, [0, 1, 2],
     !listconcat(traits, [
       DeclareOpInterfaceMethods<PromotableMemOpInterface>,
@@ -175,7 +176,8 @@ class LLVM_MemcpyIntrOpBase<string name, list<Trait> traits = []> :
       DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>
     ]),
     /*requiresAccessGroup=*/1, /*requiresAliasAnalysis=*/1,
-    /*immArgPositions=*/[3], /*immArgAttrNames=*/["isVolatile"]> {
+    /*immArgPositions=*/[3], /*immArgAttrNames=*/["isVolatile"],
+    requiresTBAAStruct> {
   dag args = (ins Arg<LLVM_AnyPointer,"",[MemWrite]>:$dst,
                   Arg<LLVM_AnyPointer,"",[MemRead]>:$src,
                   AnySignlessInteger:$len, I1Attr:$isVolatile);
@@ -197,7 +199,8 @@ class LLVM_MemcpyIntrOpBase<string name, list<Trait> traits = []> :
 }
 
 def LLVM_MemcpyOp : LLVM_MemcpyIntrOpBase<"memcpy",
-    [DeclareOpInterfaceMethods<TBAAStructOpInterface>]>
+    [DeclareOpInterfaceMethods<TBAAStructOpInterface>],
+    /*requiresTBAAStruct =*/1> {
   dag struct_arg = (ins OptionalAttr<LLVM_TBAAStructTagAttr>:$tbaa_struct);
   let arguments = !con(!con(args, aliasAttrs), struct_arg);
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -167,11 +167,13 @@ def LLVM_SMinOp : LLVM_BinarySameArgsIntrOpI<"smin">;
 def LLVM_UMaxOp : LLVM_BinarySameArgsIntrOpI<"umax">;
 def LLVM_UMinOp : LLVM_BinarySameArgsIntrOpI<"umin">;
 
-class LLVM_MemcpyIntrOpBase<string name> :
+class LLVM_MemcpyIntrOpBase<string name, list<Trait> traits = []> :
     LLVM_ZeroResultIntrOp<name, [0, 1, 2],
-    [DeclareOpInterfaceMethods<PromotableMemOpInterface>,
-     DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
-     DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>],
+    !listconcat(traits, [
+      DeclareOpInterfaceMethods<PromotableMemOpInterface>,
+      DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+      DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>
+    ]),
     /*requiresAccessGroup=*/1, /*requiresAliasAnalysis=*/1,
     /*immArgPositions=*/[3], /*immArgAttrNames=*/["isVolatile"]> {
   dag args = (ins Arg<LLVM_AnyPointer,"",[MemWrite]>:$dst,
@@ -194,7 +196,29 @@ class LLVM_MemcpyIntrOpBase<string name> :
   ];
 }
 
-def LLVM_MemcpyOp : LLVM_MemcpyIntrOpBase<"memcpy">;
+def LLVM_MemcpyOp : LLVM_MemcpyIntrOpBase<"memcpy",
+    [DeclareOpInterfaceMethods<TBAAStructOpInterface>]>
+  dag struct_arg = (ins OptionalAttr<LLVM_TBAAStructTagAttr>:$tbaa_struct);
+  let arguments = !con(!con(args, aliasAttrs), struct_arg);
+
+  let builders = [
+    OpBuilder<(ins "Value":$dst, "Value":$src, "Value":$len,
+                   "bool":$isVolatile,
+                   CArg<"TBAAStructTagAttr", "nullptr">:$tbaa_struct), [{
+      build($_builder, $_state, dst, src, len,
+            $_builder.getBoolAttr(isVolatile), tbaa_struct);
+    }]>,
+    OpBuilder<(ins "Value":$dst, "Value":$src, "Value":$len,
+                   "IntegerAttr":$isVolatile,
+                   "TBAAStructTagAttr":$tbaa_struct), [{
+      build($_builder, $_state, dst, src, len, isVolatile,
+            /*access_groups=*/nullptr, /*alias_scopes=*/nullptr,
+            /*noalias_scopes=*/nullptr, /*tbaa=*/nullptr,
+            tbaa_struct);
+    }]>
+  ];
+}
+
 def LLVM_MemmoveOp : LLVM_MemcpyIntrOpBase<"memmove">;
 
 def LLVM_MemcpyInlineOp :

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOpBase.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOpBase.td
@@ -236,6 +236,9 @@ class LLVM_MemOpPatterns {
     moduleTranslation.setAliasScopeMetadata(op, inst);
     moduleTranslation.setTBAAMetadata(op, inst);
   }];
+  code setTBAAStructMetadataCode = [{
+    moduleTranslation.setTBAAStructMetadata(op, inst);
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -293,7 +296,8 @@ class LLVM_IntrOpBase<Dialect dialect, string opName, string enumName,
                       bit requiresAccessGroup = 0, bit requiresAliasAnalysis = 0,
                       bit requiresFastmath = 0,
                       list<int> immArgPositions = [],
-                      list<string> immArgAttrNames = []>
+                      list<string> immArgAttrNames = [],
+                      bit requiresTBAAStruct = 0>
     : LLVM_OpBase<dialect, opName, !listconcat(
         !if(!gt(requiresAccessGroup, 0),
             [DeclareOpInterfaceMethods<AccessGroupOpInterface>], []),
@@ -327,6 +331,7 @@ class LLVM_IntrOpBase<Dialect dialect, string opName, string enumName,
     (void) inst;
     }] # !if(!gt(requiresAccessGroup, 0), setAccessGroupsMetadataCode, "")
        # !if(!gt(requiresAliasAnalysis, 0), setAliasAnalysisMetadataCode, "")
+       # !if(!gt(requiresTBAAStruct, 0), setTBAAStructMetadataCode, "")
        # !if(!gt(numResults, 0), "$res = inst;", "");
 
   string mlirBuilder = [{
@@ -357,11 +362,13 @@ class LLVM_IntrOp<string mnem, list<int> overloadedResults,
                   int numResults, bit requiresAccessGroup = 0,
                   bit requiresAliasAnalysis = 0, bit requiresFastmath = 0,
                   list<int> immArgPositions = [],
-                  list<string> immArgAttrNames = []>
+                  list<string> immArgAttrNames = [],
+                  bit requiresTBAAStruct = 0>
     : LLVM_IntrOpBase<LLVM_Dialect, "intr." # mnem, !subst(".", "_", mnem),
                       overloadedResults, overloadedOperands, traits,
                       numResults, requiresAccessGroup, requiresAliasAnalysis,
-                      requiresFastmath, immArgPositions, immArgAttrNames>;
+                      requiresFastmath, immArgPositions, immArgAttrNames,
+                      requiresTBAAStruct>;
 
 // Base class for LLVM intrinsic operations returning no results. Places the
 // intrinsic into the LLVM dialect and prefixes its name with "intr.".
@@ -382,10 +389,12 @@ class LLVM_ZeroResultIntrOp<string mnem, list<int> overloadedOperands = [],
                             bit requiresAccessGroup = 0,
                             bit requiresAliasAnalysis = 0,
                             list<int> immArgPositions = [],
-                            list<string> immArgAttrNames = []>
+                            list<string> immArgAttrNames = [],
+                            bit requiresTBAAStruct = 0>
     : LLVM_IntrOp<mnem, [], overloadedOperands, traits, /*numResults=*/0,
                   requiresAccessGroup, requiresAliasAnalysis,
-                  /*requiresFastMath=*/0, immArgPositions, immArgAttrNames>;
+                  /*requiresFastMath=*/0, immArgPositions, immArgAttrNames,
+                  requiresTBAAStruct>;
 
 // Base class for LLVM intrinsic operations returning one result. Places the
 // intrinsic into the LLVM dialect and prefixes its name with "intr.". This is

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -160,6 +160,9 @@ public:
   /// Sets LLVM TBAA metadata for memory operations that have TBAA attributes.
   void setTBAAMetadata(AliasAnalysisOpInterface op, llvm::Instruction *inst);
 
+  /// Sets LLVM TBAA metadata for memory operations that have TBAA attributes.
+  void setTBAAStructMetadata(TBAAStructOpInterface op, llvm::Instruction *inst);
+
   /// Sets LLVM profiling metadata for operations that have branch weights.
   void setBranchWeightsMetadata(BranchWeightOpInterface op);
 
@@ -324,6 +327,10 @@ private:
   /// Returns the LLVM metadata corresponding to the given mlir LLVM dialect
   /// TBAATagAttr.
   llvm::MDNode *getTBAANode(TBAATagAttr tbaaAttr) const;
+
+  /// Returns the LLVM metadata corresponding to the given mlir LLVM dialect
+  /// TBAAStructTagAttr.
+  llvm::MDNode *getTBAAStructNode(TBAAStructTagAttr tbaaAttr) const;
 
   /// Process tbaa LLVM Metadata operations and create LLVM
   /// metadata nodes for them.

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -330,8 +330,8 @@ LogicalResult ModuleImport::processTBAAMetadata(const llvm::MDNode *node) {
   // TBAA tag metadata operand for a valid TBAA node (i.e. when true is
   // returned).
   auto isStructNode = [&](const llvm::MDNode *node,
-      SmallVector<TBAAStructMemberAttr> *memberAttrs) -> std::optional<bool> {
-
+                          SmallVector<TBAAStructMemberAttr> *memberAttrs)
+      -> std::optional<bool> {
     // Ensure we have groups of 3
     unsigned numOperands = node->getNumOperands();
     if (numOperands % 3 != 0)
@@ -346,23 +346,22 @@ LogicalResult ModuleImport::processTBAAMetadata(const llvm::MDNode *node) {
           node->getOperand(index++));
       auto *sizeCI = llvm::mdconst::dyn_extract<llvm::ConstantInt>(
           node->getOperand(index++));
-      const auto *tagNode = dyn_cast<const llvm::MDNode>(
-          node->getOperand(index++));
+      const auto *tagNode =
+          dyn_cast<const llvm::MDNode>(node->getOperand(index++));
       if (!offsetCI || !sizeCI || !tagNode) {
         return std::nullopt;
       }
 
-      if (auto tagAttr = llvm::dyn_cast<TBAATagAttr>(tbaaMapping.lookup(tagNode))) {
-        memberAttrs->push_back(
-           builder.getAttr<TBAAStructMemberAttr>(
-             offsetCI->getZExtValue(), sizeCI->getZExtValue(),
-             tagAttr));
+      if (auto tagAttr =
+              llvm::dyn_cast<TBAATagAttr>(tbaaMapping.lookup(tagNode))) {
+        memberAttrs->push_back(builder.getAttr<TBAAStructMemberAttr>(
+            offsetCI->getZExtValue(), sizeCI->getZExtValue(), tagAttr));
       } else {
-        emitError(loc) << "operand '" << index << "' must be a valid existing tag: "
+        emitError(loc) << "operand '" << index
+                       << "' must be a valid existing tag: "
                        << diagMD(node, llvmModule.get());
         return false;
       }
-
     }
     return true;
   };

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -1652,7 +1652,8 @@ llvm::MDNode *ModuleTranslation::getTBAANode(TBAATagAttr tbaaAttr) const {
   return tbaaMetadataMapping.lookup(tbaaAttr);
 }
 
-llvm::MDNode *ModuleTranslation::getTBAAStructNode(TBAAStructTagAttr tbaaAttr) const {
+llvm::MDNode *
+ModuleTranslation::getTBAAStructNode(TBAAStructTagAttr tbaaAttr) const {
   return tbaaMetadataMapping.lookup(tbaaAttr);
 }
 

--- a/mlir/test/Dialect/LLVMIR/tbaa-struct.mlir
+++ b/mlir/test/Dialect/LLVMIR/tbaa-struct.mlir
@@ -1,0 +1,56 @@
+// RUN: mlir-opt %s | FileCheck %s
+
+// Implement the concrete example given here:
+//  https://llvm.org/docs/LangRef.html#tbaa-metadata
+
+#tbaa_root = #llvm.tbaa_root<id = "Example TBAA">
+#tbaa_type_desc = #llvm.tbaa_type_desc<id = "omnipotent char", members = {<#tbaa_root, 0>}>
+
+#tbaa_int_desc = #llvm.tbaa_type_desc<id = "int", members = {<#tbaa_type_desc, 0>}>
+#tbaa_float_desc = #llvm.tbaa_type_desc<id = "float", members = {<#tbaa_type_desc, 0>}>
+#tbaa_double_desc = #llvm.tbaa_type_desc<id = "double", members = {<#tbaa_type_desc, 0>}>
+
+#tbaa_inner_desc = #llvm.tbaa_type_desc<id = "inner", members = {<#tbaa_int_desc, 0>, <#tbaa_float_desc, 4>}>
+#tbaa_outer_desc = #llvm.tbaa_type_desc<id = "outer", members = {<#tbaa_float_desc, 0>, <#tbaa_double_desc, 4>, <#tbaa_inner_desc, 12>}>
+
+#tbaa_tag_f = #llvm.tbaa_tag<access_type = #tbaa_float_desc, base_type = #tbaa_outer_desc, offset = 0>
+#tbaa_tag_inner_i = #llvm.tbaa_tag<access_type = #tbaa_int_desc, base_type = #tbaa_outer_desc, offset = 12>
+#tbaa_tag_inner_f = #llvm.tbaa_tag<access_type = #tbaa_float_desc, base_type = #tbaa_outer_desc, offset = 16>
+
+// CHECK-DAG: #[[ROOT:.*]] = #llvm.tbaa_root<id = "Example TBAA">
+// CHECK-DAG: #[[TYPE_DESC:.*]] = #llvm.tbaa_type_desc<id = "omnipotent char", members = {<#[[ROOT]], 0>}>
+
+// CHECK-DAG: #[[INT_DESC:.*]] = #llvm.tbaa_type_desc<id = "int", members = {<#[[TYPE_DESC]], 0>}>
+// CHECK-DAG: #[[FLOAT_DESC:.*]] = #llvm.tbaa_type_desc<id = "float", members = {<#[[TYPE_DESC]], 0>}>
+// CHECK-DAG: #[[DOUBLE_DESC:.*]] = #llvm.tbaa_type_desc<id = "double", members = {<#[[TYPE_DESC]], 0>}>
+
+// CHECK-DAG: #[[INNER_DESC:.*]] = #llvm.tbaa_type_desc<id = "inner", members = {<#[[INT_DESC]], 0>, <#[[FLOAT_DESC]], 4>}>
+// CHECK-DAG: #[[OUTER_DESC:.*]] = #llvm.tbaa_type_desc<id = "outer", members = {<#[[FLOAT_DESC]], 0>, <#[[DOUBLE_DESC]], 4>, <#[[INNER_DESC]], 12>}>
+
+// CHECK-DAG: #[[F_TAG:.*]] = #llvm.tbaa_tag<base_type = #[[OUTER_DESC]], access_type = #[[FLOAT_DESC]], offset = 0>
+// CHECK-DAG: #[[INNER_I_TAG:.*]] = #llvm.tbaa_tag<base_type = #[[OUTER_DESC]], access_type = #[[INT_DESC]], offset = 12>
+// CHECK-DAG: #[[INNER_F_TAG:.*]] = #llvm.tbaa_tag<base_type = #[[OUTER_DESC]], access_type = #[[FLOAT_DESC]], offset = 16>
+
+llvm.func @tbaa_store(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
+  %f0 = llvm.mlir.constant(0.0 : f32) : f32
+  %i0 = llvm.mlir.constant(0 : i32) : i32
+  llvm.store %f0, %arg0 {tbaa = [#tbaa_tag_f]} : f32, !llvm.ptr
+  llvm.store %i0, %arg1 {tbaa = [#tbaa_tag_inner_i]} : i32, !llvm.ptr
+  llvm.store %f0, %arg2 {tbaa = [#tbaa_tag_inner_f]} : f32, !llvm.ptr
+  llvm.return
+}
+
+#tbaa_struct_outer = #llvm.tbaa_struct_tag<members={<0, 4, #tbaa_tag_f>, <12, 4, #tbaa_tag_inner_i>, <16, 4, #tbaa_tag_inner_f>}>
+
+// CHECK: llvm.func @tbaa_memcpy(%[[PTR:.*]]: !llvm.ptr) {
+// CHECK: %[[ZERO:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK: "llvm.intr.memcpy"
+// CHECK: "llvm.intr.memcpy"(%[[PTR]], %[[PTR]], %[[ZERO]]) <{isVolatile = true,
+// CHECK-SAME: tbaa_struct = #llvm.tbaa_struct_tag<members = {<0, 4, #[[F_TAG]]>, <12, 4, #[[INNER_I_TAG]]>, <16, 4, #[[INNER_F_TAG]]>}>
+
+llvm.func @tbaa_memcpy(%ptr: !llvm.ptr) {
+  %0 = llvm.mlir.constant(42 : i32) : i32
+  "llvm.intr.memcpy"(%ptr, %ptr, %0) <{isVolatile = true}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+  "llvm.intr.memcpy"(%ptr, %ptr, %0) <{isVolatile = true, tbaa_struct = #tbaa_struct_outer}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/Import/metadata-tbaa-struct.ll
+++ b/mlir/test/Target/LLVMIR/Import/metadata-tbaa-struct.ll
@@ -1,0 +1,21 @@
+; RUN: mlir-translate -import-llvm %s | FileCheck %s
+
+!0 = !{!1, !1, i64 0}
+!1 = !{!"scalar type", !2, i64 0}
+!2 = !{}
+
+!3 = !{i64 0, i64 4, !0, i64 8, i64 4, !0}
+
+; CHECK: llvm.func @memcpy_with_tbaa_struct(
+; CHECK-SAME: %[[ARG:.*]]: !llvm.ptr) {
+; CHECK:     %[[C4:.*]] = llvm.mlir.constant(4 : i32) : i32
+; CHECK: "llvm.intr.memcpy"(%[[ARG]], %[[ARG]], %[[C4]]) <{isVolatile = false,
+; CHECK-SAME: tbaa_struct = #llvm.tbaa_struct_tag<members = {<0, 4, #tbaa_tag>, <8, 4, #tbaa_tag>}>}>
+; CHECK-SAME: (!llvm.ptr, !llvm.ptr, i32) -> ()
+
+define void @memcpy_with_tbaa_struct(ptr %arg1) {
+  call void @llvm.memcpy.p0.p0.i32(ptr %arg1, ptr %arg1, i32 4, i1 false), !tbaa.struct !3
+  ret void
+}
+
+declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i32, i1 immarg)

--- a/mlir/test/Target/LLVMIR/tbaa-struct-to-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/tbaa-struct-to-llvm.mlir
@@ -1,0 +1,23 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+#tbaa_root = #llvm.tbaa_root<id = "Example TBAA">
+#tbaa_type_desc = #llvm.tbaa_type_desc<id = "scalar type", members = {<#tbaa_root, 0>}>
+#tbaa_tag = #llvm.tbaa_tag<base_type = #tbaa_type_desc, access_type = #tbaa_type_desc, offset = 0>
+#tbaa_struct = #llvm.tbaa_struct_tag<members = {<0, 4, #tbaa_tag>, <8, 4, #tbaa_tag>}>
+
+llvm.func @memcpy_with_tbaa_struct(%arg0: !llvm.ptr) {
+  %0 = llvm.mlir.constant(4 : i32) : i32
+  "llvm.intr.memcpy"(%arg0, %arg0, %0) <{isVolatile = false, tbaa_struct = #tbaa_struct}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+  llvm.return
+}
+
+// CHECK-DAG: ![[INFO:.*]] = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK-DAG: ![[TBAA_ROOT:.*]] = !{!"Example TBAA"}
+// CHECK-DAG: ![[TBAA_TYPE_DESC:.*]] = !{!"scalar type", ![[TBAA_ROOT]], i64 0}
+// CHECK-DAG: ![[TBAA_TAG:.*]] = !{![[TBAA_TYPE_DESC]], ![[TBAA_TYPE_DESC]], i64 0}
+// CHECK-DAG: ![[TBAA_STRUCT:.*]] = !{i64 0, i64 4, ![[TBAA_TAG]], i64 8, i64 4, ![[TBAA_TAG]]}
+
+// CHECK-DAG: define void @memcpy_with_tbaa_struct(ptr %0) {
+// CHECK-DAG:   call void @llvm.memcpy.p0.p0.i32(ptr %0, ptr %0, i32 4, i1 false), !tbaa.struct ![[TBAA_STRUCT]]
+// CHECK-DAG:   ret void
+// CHECK-DAG: }


### PR DESCRIPTION
A proposed solution to [#973](https://github.com/PennyLaneAI/catalyst/issues/973)

Follows the technical details with the following notes:

- Created a new interface (`TBAAStructInterface`) to allow it to be decoupled from the `AliasAnalysis` interface and not require all those ops to implement the new interface methods
- Alter the `LLVM_MemcpyIntrOpBase` to allow additional traits. This is so that `memmove` does not need to implement a `TBAAStructTagAttr` and that we only add it for `memcpy`. Should be easily modified if `memmove` also having the struct info is desired.
- Importing of the `tbaa_struct` metadata is coupled with the other alias analysis metadata so that we can re-use the implementation of the post-order traversal
- When implementing the translation it was required to add the `requiresTBAAStruct` param to all the inherited classes. This was required so that we can add conversion code when generated.

- Added some basic tests to demonstrate functionality